### PR TITLE
Propose Fix for dataclass decorator not available before Python 3.7

### DIFF
--- a/src/gui/coord_utils.py
+++ b/src/gui/coord_utils.py
@@ -8,7 +8,9 @@ not the top left
 # Util
 
 import platform
-if not "Linux" in platform.platform():  # Hard to get Python 3.7 on Linux esp to bundle via snaps
+import sys
+
+if not "Linux" in platform.platform() and sys.version_info.minor >= 7:  # Hard to get Python 3.7 on Linux esp to bundle via snaps
     from dataclasses import dataclass
 from gui.settings import PRO_EDITION
 
@@ -88,7 +90,7 @@ def percent_change(end, start):
         # print 'There is no change in value.'
         return 0
 
-if "Linux" in platform.platform():
+if "Linux" in platform.platform() or sys.version_info.minor < 7:
     # Probably running under Python 3.6 which doesn't have data classes
     class ZoomInfo:
         def __init__(self, scale: float=1, delta: float=None):


### PR DESCRIPTION
Running from source failed on Python 3.6 on Windows machine.
Added code to check Python minor version directly, retained code checking for "Linux".
Works fine on Windows 10 with Python 3.6 now.

Possibly the code could/should just check the Python version instead of looking at the OS type?