### PR TITLE
Fixed float/int argument type mismatch in several wxPython calls

### DIFF
--- a/src/common/gui_imageviewer.py
+++ b/src/common/gui_imageviewer.py
@@ -395,13 +395,13 @@ class ImageViewer(wx.ScrolledWindow):
                     print(f"Nothing to do, step of {newstep} already set.")
             else:
                 q = newstep / oldstep  # min(1, newstep)
-                newscrollx = oldscrollx / q
-                newscrolly = oldscrolly / q
+                newscrollx = int(oldscrollx / q)
+                newscrolly = int(oldscrolly / q)
                 # newvirtx = oldvirtx / q
                 # newvirty = oldvirty / q
                 # Aha - image size * step => virtual bounds
-                newvirtx = self.maxWidth / newstep * self.zoomscale
-                newvirty = self.maxHeight / newstep * self.zoomscale
+                newvirtx = int(self.maxWidth / newstep * self.zoomscale)
+                newvirty = int(self.maxHeight / newstep * self.zoomscale)
                 if printinfo:
                     print(f"OUT step {newstep}          new scroll {newscrollx}, {newscrolly} virt {newvirtx}, {newvirty} q {q}")
 
@@ -724,7 +724,7 @@ class ImageViewer(wx.ScrolledWindow):
         dc.SetPen(wx.Pen("MEDIUM FOREST GREEN", 4))
         for line in self.lines:
             for coords in line:
-                dc.DrawLine(*coords)
+                dc.DrawLine(*map(int, coords))
 
     def OnClearPenLines(self, event):
         self.clear_pen_lines()

--- a/src/gui/canvas_resizer.py
+++ b/src/gui/canvas_resizer.py
@@ -188,7 +188,7 @@ class CanvasResizer(object):
         # https://wxpython.org/Phoenix/docs/html/wx.Scrolled.html#wx.Scrolled.SetScrollbars
         self.canvas.SetScrollbars(
             1, 1,  # each scroll unit is 1 pixel, meaning scroll units match client coord units
-            bounds_width, bounds_height,  # new virtual size
+            int(bounds_width), int(bounds_height),  # new virtual size
             oldscrollx, oldscrolly,  # new scroll positions
             noRefresh=True
         )

--- a/src/gui/uml_shapes.py
+++ b/src/gui/uml_shapes.py
@@ -258,8 +258,8 @@ class CommentShape(ogl.RectangleShape):
 
         # print("drawing comment shape....")
 
-        x1 = self._xpos - self._width / 2.0
-        y1 = self._ypos - self._height / 2.0
+        x1 = int(self._xpos - self._width / 2.0)
+        y1 = int(self._ypos - self._height / 2.0)
         x2 = x1 + self._width
         y2 = y1 + self._height
 


### PR DESCRIPTION
Python 3.10 no longer does automatic float to int conversion where necessary. wxPython function usually expect pixel coordinates as integers and fail if floats are supplied.

Fixes: #114